### PR TITLE
feat: implement dynamic TOTP secret fetching and fallback mechanism

### DIFF
--- a/services/spotifyAuthService.js
+++ b/services/spotifyAuthService.js
@@ -1,22 +1,121 @@
 import axios from "axios";
 import * as OTPAuth from "otpauth";
+import dotenv from "dotenv";
+
+dotenv.config();
 
 const SP_DC = process.env.SP_DC;
+const SECRETS_URL = "https://raw.githubusercontent.com/Thereallo1026/spotify-secrets/refs/heads/main/secrets/secretDict.json";
 
-const totpSecret = (function (data) {
-    const mappedData = data.map((value, index) => value ^ ((index % 33) + 9));
-    const hexData = Buffer.from(mappedData.join(""), "utf8").toString("hex");
-    return OTPAuth.Secret.fromHex(hexData);
-})([99, 111, 47, 88, 49, 56, 118, 65, 52, 67, 50, 104, 117, 101, 55, 94, 95, 75, 94, 49, 69, 36, 85, 64, 74, 60]);
+// Global variables to store the current TOTP configuration
+let currentTotp = null;
+let currentTotpVersion = null;
+let lastFetchTime = 0;
+const FETCH_INTERVAL = 60 * 60 * 1000; // 1 hour in milliseconds
 
-const totp = new OTPAuth.TOTP({
-  period: 30,
-  digits: 6,
-  algorithm: "SHA1",
-  secret: totpSecret
-});
+// Initialize TOTP secrets on startup
+initializeTOTPSecrets();
+
+// Set up periodic updates
+setInterval(updateTOTPSecrets, FETCH_INTERVAL);
+
+async function initializeTOTPSecrets() {
+  try {
+    await updateTOTPSecrets();
+  } catch (error) {
+    console.error('Failed to initialize TOTP secrets:', error);
+    // Fallback to the original hardcoded secret
+    useFallbackSecret();
+  }
+}
+
+async function updateTOTPSecrets() {
+  try {
+    const now = Date.now();
+    if (now - lastFetchTime < FETCH_INTERVAL) {
+      return; // Don't fetch too frequently
+    }
+
+    console.log('Fetching updated TOTP secrets...');
+    const secrets = await fetchSecretsFromGitHub();
+    const newestVersion = findNewestVersion(secrets);
+    
+    if (newestVersion && newestVersion !== currentTotpVersion) {
+      const secretData = secrets[newestVersion];
+      const totpSecret = createTotpSecret(secretData);
+      
+      currentTotp = new OTPAuth.TOTP({
+        period: 30,
+        digits: 6,
+        algorithm: "SHA1",
+        secret: totpSecret
+      });
+      
+      currentTotpVersion = newestVersion;
+      lastFetchTime = now;
+      console.log(`TOTP secrets updated to version ${newestVersion}`);
+    } else {
+      console.log(`No new TOTP secrets found, using version ${newestVersion}`);
+    }
+  } catch (error) {
+    console.error('Failed to update TOTP secrets:', error);
+    // Keep using current TOTP if available, otherwise use fallback
+    if (!currentTotp) {
+      useFallbackSecret();
+    }
+  }
+}
+
+async function fetchSecretsFromGitHub() {
+  try {
+    const response = await axios.get(SECRETS_URL, {
+      timeout: 10000,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch secrets from GitHub:', error.message);
+    throw error;
+  }
+}
+
+function findNewestVersion(secrets) {
+  const versions = Object.keys(secrets).map(Number);
+  return Math.max(...versions).toString();
+}
+
+function createTotpSecret(data) {
+  const mappedData = data.map((value, index) => value ^ ((index % 33) + 9));
+  const hexData = Buffer.from(mappedData.join(""), "utf8").toString("hex");
+  return OTPAuth.Secret.fromHex(hexData);
+}
+
+function useFallbackSecret() {
+  // Fallback to the original hardcoded secret
+  // This secret will most likely fail because Spotify is rotating the secrets every couple of days
+  // This is really just kept in here for reference
+  const fallbackData = [99, 111, 47, 88, 49, 56, 118, 65, 52, 67, 50, 104, 117, 101, 55, 94, 95, 75, 94, 49, 69, 36, 85, 64, 74, 60];
+  const totpSecret = createTotpSecret(fallbackData);
+  
+  currentTotp = new OTPAuth.TOTP({
+    period: 30,
+    digits: 6,
+    algorithm: "SHA1",
+    secret: totpSecret
+  });
+  
+  currentTotpVersion = "19"; // Fallback version
+  console.log('Using fallback TOTP secret');
+}
 
 export async function getToken(reason = "init", productType = "mobile-web-player") {
+  // Ensure we have a TOTP instance
+  if (!currentTotp) {
+    await initializeTOTPSecrets();
+  }
+
   const payload = await generateAuthPayload(reason, productType);
 
   const url = new URL("https://open.spotify.com/api/token");
@@ -42,7 +141,7 @@ async function generateAuthPayload(reason, productType) {
     reason,
     productType,
     totp: generateTOTP(localTime),
-    totpVer: "19",
+    totpVer: currentTotpVersion || "19",
     totpServer: generateTOTP(Math.floor(serverTime / 30))
   };
 }
@@ -67,7 +166,10 @@ async function getServerTime() {
 }
 
 function generateTOTP(timestamp) {
-  return totp.generate({ timestamp });
+  if (!currentTotp) {
+    throw new Error("TOTP not initialized");
+  }
+  return currentTotp.generate({ timestamp });
 }
 
 function userAgent() {


### PR DESCRIPTION
This PR implements automatic fetching of TOTP secrets from the [Spotify secrets repository](https://github.com/Thereallo1026/spotify-secrets/), replacing the hardcoded secret with a dynamic system that automatically updates to use the newest available tokens. #2 

- Fetches TOTP secrets from spotify-secrets repository
- Automatically fetches latest secrets when the application starts
- Checks for new tokens every hour using setInterval
- Automatically selects the highest version number from available secrets
- "Graceful" Fallback: Falls back to original secret if GitHub fetch fails (for reference only)
- TOTP is now generated dynamically based on fetched secrets
---
The fallback secret is kept for reference but will likely fail as Spotify rotates secrets frequently. The system automatically handles the transition to new secrets without service interruption

I also added dotenv import in spotifyAuthService.